### PR TITLE
Update grid_trader.py

### DIFF
--- a/grid_trader.py
+++ b/grid_trader.py
@@ -215,7 +215,7 @@ class GridTrader:
         """计算订单数量"""
         grid_investment = self.investment / self.grid_number
         amount = grid_investment / price
-        return max(round(amount, 3), self.min_order_size)
+        return max(round(amount, 2), self.min_order_size)
 
     def check_balance(self, side: str, amount: float, price: float) -> bool:
         """检查账户余额是否足够"""


### PR DESCRIPTION
修复 Quantity decimal too long
使用 sol 现货网格时，发生的错误，amount精度超长了，建议限制成2位，然后就没请求的报错了。

提了 issue
https://github.com/Dazmon00/Backpack-bot/issues/1